### PR TITLE
Added ImageMode tag for the specific tests

### DIFF
--- a/Sanity/upstream-testsuite/main.fmf
+++ b/Sanity/upstream-testsuite/main.fmf
@@ -10,6 +10,7 @@ recommend:
 tag:
   - CI-Tier-1
   - Tier1
+  - ImageMode
 tier: '1'
 duration: 10m
 enabled: true

--- a/Security/cve-2024-27982-http-request-smuggling/main.fmf
+++ b/Security/cve-2024-27982-http-request-smuggling/main.fmf
@@ -8,3 +8,5 @@ recommend:
 - dnf-plugins-core
 duration: 10m
 enabled: true
+tag:
+  - ImageMode


### PR DESCRIPTION
## Summary by Sourcery

Tag selected FMF test definitions with the ImageMode metadata to ensure proper test classification

Tests:
- Add ImageMode tag to upstream-testsuite/main.fmf definitions
- Add ImageMode tag to cve-2024-27982-http-request-smuggling main.fmf definitions